### PR TITLE
crutch for

### DIFF
--- a/graph-executor/src/main/java/ai/lzy/graph/db/QueueEventDao.java
+++ b/graph-executor/src/main/java/ai/lzy/graph/db/QueueEventDao.java
@@ -3,11 +3,12 @@ package ai.lzy.graph.db;
 import ai.lzy.graph.model.QueueEvent;
 import ai.lzy.model.db.exceptions.DaoException;
 
+import java.sql.SQLException;
 import java.util.List;
 
 public interface QueueEventDao {
 
-    void add(QueueEvent.Type type, String workflowId, String graphId, String description) throws DaoException;
+    void add(QueueEvent.Type type, String workflowId, String graphId, String description) throws SQLException;
 
     List<QueueEvent> acquireWithLimit(int limit) throws DaoException;
 

--- a/graph-executor/src/main/java/ai/lzy/graph/db/impl/QueueEventDaoImpl.java
+++ b/graph-executor/src/main/java/ai/lzy/graph/db/impl/QueueEventDaoImpl.java
@@ -24,7 +24,7 @@ public class QueueEventDaoImpl implements QueueEventDao {
     }
 
     @Override
-    public void add(QueueEvent.Type type, String workflowId, String graphId, String description) throws DaoException {
+    public void add(QueueEvent.Type type, String workflowId, String graphId, String description) throws SQLException {
         try (var con = storage.connect();
              var st = con.prepareStatement("""
                 INSERT INTO queue_event (
@@ -43,8 +43,6 @@ public class QueueEventDaoImpl implements QueueEventDao {
             st.setBoolean(5, false);
             st.setString(6, event.description());
             st.execute();
-        } catch (SQLException e) {
-            throw new DaoException(e);
         }
     }
 


### PR DESCRIPTION
2022-12-02 12:34:43.527 [Time-limited test] ERROR ai.lzy.graph.queue.QueueManager - Got retryable database error #1: [40001] ERROR: could not serialize access due to concurrent update
  Where: SQL statement "SELECT 1 FROM ONLY "public"."graph_execution_state" x WHERE "workflow_id"::pg_catalog.text OPERATOR(pg_catalog.=) $1::pg_catalog.text AND "id"::pg_catalog.text OPERATOR(pg_catalog.=) $2::pg_catalog.text FOR KEY SHARE OF x". Retry after 50ms.