### PR TITLE
Fix editable installation of lzy

### DIFF
--- a/pylzy/lzy/api/v1/remote/runtime.py
+++ b/pylzy/lzy/api/v1/remote/runtime.py
@@ -46,7 +46,7 @@ from lzy.api.v1.runtime import (
 )
 from lzy.api.v1.startup import ProcessingRequest
 from lzy.api.v1.utils.conda import generate_conda_yaml
-from lzy.api.v1.utils.files import fileobj_hash, zip_module, sys_path_parent
+from lzy.api.v1.utils.files import fileobj_hash, zip_module
 from lzy.api.v1.utils.pickle import pickle
 from lzy.api.v1.workflow import LzyWorkflow
 from lzy.logs.config import get_logger, get_logging_config, RESET_COLOR, COLOURS, get_color
@@ -205,15 +205,9 @@ class RemoteRuntime(Runtime):
         for local_module in module_paths:
 
             with tempfile.NamedTemporaryFile("rb") as archive:
-                if not os.path.isdir(local_module):
-                    prefix = sys_path_parent(local_module)
-                    if prefix is None:
-                        raise RuntimeError(f'Invalid local module path {local_module}')
-                    with zipfile.ZipFile(archive.name, "w") as z:
-                        z.write(local_module, (Path(local_module).relative_to(prefix)))
-                else:
-                    with zipfile.ZipFile(archive.name, "w") as z:
-                        zip_module(local_module, z)
+                with zipfile.ZipFile(archive.name, "w") as z:
+                    zip_module(local_module, z)
+
                 archive.seek(0)
                 file = cast(BytesIO, archive.file)
                 key = os.path.join(

--- a/pylzy/lzy/api/v1/utils/files.py
+++ b/pylzy/lzy/api/v1/utils/files.py
@@ -2,14 +2,15 @@ import hashlib
 import os
 from io import BytesIO
 from pathlib import Path
+from typing import Union, List
 from zipfile import ZipFile
 
 
-def zip_module(path: str, zipfile: ZipFile):
+def zip_module(path: Union[str, Path], zipfile: ZipFile):
     path = Path(path)
     relative_to = path.parent
 
-    paths = []
+    paths: List[Path] = []
     if path.is_dir():
         for root, _, files in os.walk(path):
             paths.extend(Path(root) / filename for filename in files)

--- a/pylzy/lzy/api/v1/utils/files.py
+++ b/pylzy/lzy/api/v1/utils/files.py
@@ -1,31 +1,24 @@
 import hashlib
 import os
-import sys
 from io import BytesIO
 from pathlib import Path
-from typing import Optional
 from zipfile import ZipFile
 
 
-def sys_path_parent(path: str) -> Optional[str]:
-    prefix: Optional[str] = None
-    module_parent_dir = str(Path(path).parent)
-    for relative in sys.path:
-        if relative == module_parent_dir:
-            prefix = relative
-            break
-    return prefix
-
-
 def zip_module(path: str, zipfile: ZipFile):
-    relative_to: Optional[str] = sys_path_parent(path)
-    if relative_to is None:
-        raise ValueError(f'Unexpected local module location: {path}')
+    path = Path(path)
+    relative_to = path.parent
 
-    for root, dirs, files in os.walk(path):
-        for file in files:
-            file_path = (Path(root) / file).relative_to(relative_to)
-            zipfile.write((Path(root) / file), file_path)
+    paths = []
+    if path.is_dir():
+        for root, _, files in os.walk(path):
+            paths.extend(Path(root) / filename for filename in files)
+    else:
+        paths.append(path)
+
+    for path_at_fs in paths:
+        path_to_write = path_at_fs.relative_to(relative_to)
+        zipfile.write(path_at_fs, path_to_write)
 
 
 def fileobj_hash(fileobj: BytesIO) -> str:

--- a/pylzy/tests/env_provider/test_modules_search.py
+++ b/pylzy/tests/env_provider/test_modules_search.py
@@ -5,7 +5,6 @@ import sys
 from pathlib import Path
 from unittest import TestCase
 
-from lzy.api.v1.utils.files import sys_path_parent
 from lzy.py_env.api import PyEnvProvider
 from lzy.py_env.py_env_provider import AutomaticPyEnvProvider
 
@@ -49,11 +48,6 @@ class ModulesSearchTests(TestCase):
             len(local_modules_path)
         )
 
-        for local in local_modules_path:
-            prefix = sys_path_parent(local)
-            path = (Path(local).relative_to(prefix))
-            self.assertIsNotNone(path)
-
         # noinspection DuplicatedCode
         for path in (
             "modules_for_tests",
@@ -86,11 +80,6 @@ class ModulesSearchTests(TestCase):
             2 if sys.version_info < (3, 10) else 1,  # typing extensions is a standard module starting from 3.10
             len(local_modules_path)
         )
-
-        for local in local_modules_path:
-            prefix = sys_path_parent(local)
-            path = Path(local).relative_to(prefix)
-            self.assertIsNotNone(path)
 
         for path in (
             "modules_for_tests",


### PR DESCRIPTION
Before this PR, `zip_module` function did two things:
1) cut off parent of lib dir from lib files path (so instead of `<...>/site-packages/<lib>/file` we got only `<lib>/file`
2) check that parent path (`<...>/site-packages`) is inside `sys.path`

We tried to figure out with @mrMakaronka why do we need p.2 check, but we failed.
On the other hand, this check prevents from installing and using pylzy in editable mode (`pip install -e .`), which creates difficulties for developement.

So we decided to remove this check for now and wait for something break.
If something will break, I would add special code branch for libraries which installed in editable mode and will return this check.

