### PR TITLE
Now storage url has no empty parts between slash delimiter (#949)

### DIFF
--- a/pylzy/tests/api/v1/test_entries.py
+++ b/pylzy/tests/api/v1/test_entries.py
@@ -115,6 +115,14 @@ class LzyEntriesTests(TestCase):
         storage_client = cast(StorageClientMock, self.lzy.storage_client)
         self.assertEqual(1, storage_client.store_counts[uri_1])
 
+    def test_with_empty_args(self):
+        with self.lzy.workflow("test") as wf:
+            foo_varargs()
+
+        # noinspection PyUnresolvedReferences
+        uri_1 = wf.snapshot.get(wf.owner.runtime.calls[0].entry_ids[0]).storage_uri
+        self.assertTrue(all(uri_1.split("/")))
+
     def test_uris_gen_for_repeating_arg(self):
         n: str = 'length'
 


### PR DESCRIPTION
(cherry picked from commit e23c80c67070d87910c926211c3fdd0484079c3b)